### PR TITLE
ci: add npm-publish caller workflow for OIDC trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,10 @@
+name: Node.js Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    uses: ./.github/workflows/npm-publish-reusable.yml
+    secrets: inherit


### PR DESCRIPTION
## Summary

- Seeds the public repo with `.github/workflows/npm-publish.yml`, the caller workflow that fires on `release: published` and invokes the reusable `npm-publish-reusable.yml` (which gets synced over from the monorepo on the next tag-driven release).
- Required so that npm Trusted Publisher (OIDC) for `@opensea/tool-sdk` has a workflow to validate against on first automated publish. Mirrors the existing setup on `ProjectOpenSea/wallet-adapters`.

## Test plan

- [ ] PR merges into `main`
- [ ] On next `tool-sdk-v*` release in the monorepo, `sync-package` lands `npm-publish-reusable.yml` next to this file and triggers `npm publish --provenance` via OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)