### PR TITLE
fix(predicate-gate): require validBefore in X-Payment authorization

### DIFF
--- a/src/__tests__/predicate-gate.test.ts
+++ b/src/__tests__/predicate-gate.test.ts
@@ -683,6 +683,54 @@ describe("predicateGate", () => {
     })
   })
 
+  it("X-Payment: rejects an authorization that omits validBefore", async () => {
+    const { predicateGate } = await import(
+      "../lib/middleware/predicate-gate.js"
+    )
+    const operator =
+      "0x5ECA0441311643608a8c9Ab8B250f695Dd32E2a8" as `0x${string}`
+    const gate = predicateGate({
+      toolId: TEST_TOOL_ID,
+      operatorAddress: operator,
+    })
+    const ctx: Partial<ToolContext> = { gates: {} }
+
+    // Authorization with NO validBefore. The signer (recovery mock -> TEST_CALLER)
+    // matches `from`, so the expiry check is the only bound on this token. When
+    // validBefore is absent that check is skipped, so an unbounded (non-expiring)
+    // proof is accepted. The sibling EIP-3009 path (verifyEip3009Auth) requires
+    // validBefore, so the two auth paths must agree: reject when it is missing.
+    const header = Buffer.from(
+      JSON.stringify({
+        x402Version: 1,
+        scheme: "exact",
+        network: "base",
+        payload: {
+          signature: "0xabcd",
+          authorization: {
+            from: TEST_CALLER,
+            to: operator,
+            value: "0",
+            validAfter: "0",
+            // validBefore intentionally omitted
+            nonce:
+              "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+          },
+        },
+      }),
+    ).toString("base64")
+    const request = new Request("https://example.com/api", {
+      method: "POST",
+      headers: { "X-Payment": header },
+    })
+
+    const response = await gate.check(request, ctx)
+
+    expect(response?.status).toBe(401)
+    const body = await response?.json()
+    expect(body.error).toMatch(/missing required authorization fields/i)
+  })
+
   it("X-Payment: takes precedence over Authorization header", async () => {
     const { predicateGate } = await import(
       "../lib/middleware/predicate-gate.js"

--- a/src/lib/middleware/predicate-gate.ts
+++ b/src/lib/middleware/predicate-gate.ts
@@ -522,7 +522,7 @@ async function verifyXPaymentAuth(
   const auth = paymentPayload.payload?.authorization
   const signature = paymentPayload.payload?.signature
 
-  if (!auth?.from || !auth?.to || !signature || !auth?.nonce) {
+  if (!auth?.from || !auth?.to || !signature || !auth?.nonce || !auth?.validBefore) {
     return {
       error:
         "Predicate gate: X-Payment missing required authorization fields",


### PR DESCRIPTION
## What

Require `validBefore` in the X-Payment authorization verified by `predicateGate`, so an authorization that omits the field is rejected instead of accepted as a proof with no expiry bound.

Closes #9.

## Why

In `verifyXPaymentAuth` (`src/lib/middleware/predicate-gate.ts`) `validBefore` was effectively optional on three lines:

- the required-field check did not include it (only `from` / `to` / `signature` / `nonce`),
- the expiry comparison was guarded by `if (auth.validBefore !== undefined)`, so it was skipped when the field was absent,
- signature recovery fell back to `BigInt(auth.validBefore ?? "0")`.

So a caller can sign a `TransferWithAuthorization` with `validBefore = 0` and send an X-Payment payload that omits the field. Recovery uses the same `0`, the signature matches `from`, and the expiry check never runs, so the gate accepts a proof with no upper time bound. Sending `validBefore: "0"` explicitly is correctly rejected as expired; only omitting it slips through.

The sibling EIP-3009 path (`verifyEip3009Auth`) already requires `validBefore`: it calls `BigInt(authorization.validBefore)` with no `?? "0"` fallback, so a missing value throws and the request is rejected. This change makes the two auth paths consistent. The predicate-gating guide also recommends keeping `validBefore` short to bound the replay window, which is only enforceable if the field is mandatory.

## Change

One line: add `!auth?.validBefore` to the existing required-field check, matching the falsy-checks already used for the other fields. This also rejects an empty-string `validBefore` (which would otherwise reach `BigInt("")`).

## Test

Adds `X-Payment: rejects an authorization that omits validBefore` to `predicate-gate.test.ts`.

Against the current code the test fails - the gate returns `null` (access granted):

```
AssertionError: expected undefined to be 401
```

With the fix it passes, and the full suite stays green:

```
Test Files  39 passed (39)
      Tests  632 passed (632)
```
