### PR TITLE
fix(x402): validate server payment requirements before signing in pay and eip3009AuthenticatedFetch

### DIFF
--- a/src/__tests__/validate-payment-requirements.test.ts
+++ b/src/__tests__/validate-payment-requirements.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest"
+import {
+  type PaymentRequirements,
+  validatePaymentRequirements,
+} from "../lib/client/x402-payment.js"
+
+const base: PaymentRequirements = {
+  scheme: "exact",
+  network: "base",
+  maxAmountRequired: "1000000",
+  payTo: "0x1111111111111111111111111111111111111111",
+  // USDC on Base; validatePaymentRequirements rejects any other asset when
+  // allowedAssets is not provided.
+  asset: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+}
+
+describe("validatePaymentRequirements", () => {
+  it("passes for a well-formed requirement", () => {
+    expect(() => validatePaymentRequirements(base, {})).not.toThrow()
+  })
+
+  it("rejects a burn/zero payTo address", () => {
+    expect(() =>
+      validatePaymentRequirements(
+        { ...base, payTo: "0x0000000000000000000000000000000000000000" },
+        {},
+      ),
+    ).toThrow(/burn\/zero address/)
+  })
+
+  it("rejects when the server amount exceeds maxAmount", () => {
+    expect(() =>
+      validatePaymentRequirements(base, { maxAmount: "999999" }),
+    ).toThrow(/maxAmount/)
+  })
+
+  it("passes when the server amount is within maxAmount", () => {
+    expect(() =>
+      validatePaymentRequirements(base, { maxAmount: "1000000" }),
+    ).not.toThrow()
+  })
+})

--- a/src/cli/commands/pay.ts
+++ b/src/cli/commands/pay.ts
@@ -1,7 +1,10 @@
 import { Command } from "commander"
 import pc from "picocolors"
 import type { PaymentRequirements } from "../../lib/client/x402-payment.js"
-import { signX402Payment } from "../../lib/client/x402-payment.js"
+import {
+  signX402Payment,
+  validatePaymentRequirements,
+} from "../../lib/client/x402-payment.js"
 import {
   createWalletForProvider,
   createWalletFromEnv,
@@ -14,6 +17,7 @@ import { readInput } from "./read-input.js"
 interface PayOptions {
   body?: string
   walletProvider?: string
+  maxAmount?: string
 }
 
 export const payCommand = new Command("pay")
@@ -25,6 +29,10 @@ export const payCommand = new Command("pay")
   .option(
     "--wallet-provider <provider>",
     `Wallet provider: ${WALLET_PROVIDERS.join(", ")}`,
+  )
+  .option(
+    "--max-amount <atomic>",
+    "Maximum payment amount in atomic units the CLI will sign; the server's 402 requirements are rejected if they exceed it",
   )
   .action(async (url: string, options: PayOptions) => {
     let adapter: WalletAdapter
@@ -65,13 +73,14 @@ export const payCommand = new Command("pay")
       process.exit(1)
     }
 
-    await runPaymentOnly(url, inputBody, adapter)
+    await runPaymentOnly(url, inputBody, adapter, options.maxAmount)
   })
 
 async function runPaymentOnly(
   url: string,
   inputBody: string,
   adapter: WalletAdapter,
+  maxAmount?: string,
 ): Promise<void> {
   console.log(pc.cyan("Probing endpoint for payment requirements..."))
 
@@ -124,6 +133,17 @@ async function runPaymentOnly(
   console.log(`  Amount: ${requirements.maxAmountRequired}`)
   console.log(`  Pay To: ${requirements.payTo}`)
   console.log(`  Asset: ${requirements.asset}`)
+
+  try {
+    validatePaymentRequirements(requirements, { maxAmount })
+  } catch (err) {
+    console.error(
+      pc.red(
+        `Refusing to sign: ${err instanceof Error ? err.message : String(err)}`,
+      ),
+    )
+    process.exit(1)
+  }
 
   console.log(pc.cyan("\nSigning EIP-3009 transferWithAuthorization..."))
 

--- a/src/lib/client/x402-payment.ts
+++ b/src/lib/client/x402-payment.ts
@@ -233,7 +233,7 @@ export async function paidFetch(
   return paidRes
 }
 
-function validatePaymentRequirements(
+export function validatePaymentRequirements(
   reqs: PaymentRequirements,
   opts: {
     maxAmount?: string


### PR DESCRIPTION
## What

The `pay` CLI signed the server-supplied 402 payment requirements directly via `signX402Payment` without any validation. This wires the existing `validatePaymentRequirements` guard (now exported from `x402-payment`) into the CLI path before signing:

- rejects burn/zero `payTo` addresses,
- enforces the expected network USDC asset,
- with the new `--max-amount` flag, rejects amounts above the caller's cap.

Adds focused unit tests for the guard.

## Note on scope

Re-scoped after the lib-level `validatePaymentRequirements` landed in `main`: this PR now only applies that existing guard on the `pay` CLI path (which still signed server requirements unvalidated) and adds the `--max-amount` cap plus tests. Earlier auth/manifest changes were dropped to keep this focused on the validation fix.

## Testing

- `npm run type-check`
- `npm run test` (636/636 passing, including the new validate-payment-requirements suite)
- `npm run lint` (biome, clean)