### PR TITLE
fix(inspect): validate metadata URI before fetching (SSRF)

### DIFF
--- a/src/__tests__/inspect.test.ts
+++ b/src/__tests__/inspect.test.ts
@@ -109,6 +109,37 @@ describe("inspect command", () => {
     logSpy.mockRestore()
   })
 
+  it("refuses to fetch a metadata URI that points to a private address", async () => {
+    mockGetToolConfig.mockResolvedValueOnce({
+      creator: "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+      metadataURI:
+        "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
+      manifestHash: MANIFEST_HASH,
+      accessPredicate: "0x0000000000000000000000000000000000000000",
+    })
+    const fetchMock = vi.fn(async () => new Response("{}", { status: 200 }))
+    vi.stubGlobal("fetch", fetchMock)
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {})
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit")
+    }) as never)
+
+    const { inspectCommand } = await import("../cli/commands/inspect.js")
+
+    await expect(
+      inspectCommand.parseAsync(["node", "inspect", "--tool-id", "1"]),
+    ).rejects.toThrow()
+
+    // The link-local metadata address must never be fetched.
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(exitSpy).toHaveBeenCalledWith(1)
+
+    logSpy.mockRestore()
+    errSpy.mockRestore()
+    exitSpy.mockRestore()
+  })
+
   it("reports MISMATCH when computed hash differs from onchain hash", async () => {
     mockGetToolConfig.mockResolvedValueOnce({
       creator: "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",

--- a/src/cli/commands/inspect.ts
+++ b/src/cli/commands/inspect.ts
@@ -19,7 +19,11 @@ import { decodeRequirement } from "../../lib/onchain/access.js"
 import { computeManifestHash } from "../../lib/onchain/hash.js"
 import { ToolRegistryClient } from "../../lib/onchain/registry.js"
 import { getChain } from "./get-chain.js"
-import { printProbeResult, probeEndpoint } from "./probe-endpoint.js"
+import {
+  isPrivateHostname,
+  printProbeResult,
+  probeEndpoint,
+} from "./probe-endpoint.js"
 
 interface InspectOptions {
   toolId: string
@@ -253,6 +257,36 @@ export const inspectCommand = new Command("inspect")
     }
 
     console.log(pc.cyan("\nFetching manifest from metadata URI..."))
+
+    // metadataURI comes from the (permissionlessly writable) on-chain registry.
+    // Validate it before fetching so a hostile entry cannot point this fetch at
+    // an internal address (e.g. cloud metadata at 169.254.169.254) from the
+    // machine or CI runner that runs `inspect`.
+    let metadataUrl: URL
+    try {
+      metadataUrl = new URL(config.metadataURI)
+    } catch {
+      console.error(
+        pc.red(`Error: invalid metadata URI: ${config.metadataURI}`),
+      )
+      process.exit(1)
+    }
+    if (metadataUrl.protocol !== "http:" && metadataUrl.protocol !== "https:") {
+      console.error(
+        pc.red(
+          `Error: metadata URI must use http(s), got "${metadataUrl.protocol}"`,
+        ),
+      )
+      process.exit(1)
+    }
+    if (isPrivateHostname(metadataUrl.hostname)) {
+      console.error(
+        pc.red(
+          `Error: metadata URI host "${metadataUrl.hostname}" is a private/internal address; refusing to fetch`,
+        ),
+      )
+      process.exit(1)
+    }
 
     let response: globalThis.Response
     try {

--- a/src/cli/commands/probe-endpoint.ts
+++ b/src/cli/commands/probe-endpoint.ts
@@ -7,7 +7,7 @@ export interface ProbeResult {
 }
 
 const PRIVATE_HOSTNAME_RE =
-  /^(localhost|127\.\d+\.\d+\.\d+|10\.\d+\.\d+\.\d+|172\.(1[6-9]|2\d|3[01])\.\d+\.\d+|192\.168\.\d+\.\d+|\[?::1\]?|\[?fe80:)/i
+  /^(localhost|127\.\d+\.\d+\.\d+|10\.\d+\.\d+\.\d+|172\.(1[6-9]|2\d|3[01])\.\d+\.\d+|192\.168\.\d+\.\d+|169\.254\.\d+\.\d+|\[?::1\]?|\[?fe80:)/i
 
 export function isPrivateHostname(hostname: string): boolean {
   return PRIVATE_HOSTNAME_RE.test(hostname)


### PR DESCRIPTION
## What

`inspect` fetches the on-chain `metadataURI` with no validation. This validates it first so a hostile registry entry cannot point the fetch at an internal address.

## Why

`metadataURI` is read from the tool registry, which any party can write to permissionlessly, and `inspect` passes it straight to `fetch` (`src/cli/commands/inspect.ts`). A registrant can store `http://169.254.169.254/latest/meta-data/...` and post the tool id; a developer or CI runner that runs `tool-sdk inspect --tool-id <id>` then issues that request to the cloud metadata endpoint from inside the trust boundary. The `isPrivateHostname` guard already exists (it is applied to `manifest.endpoint`) but was never applied to `metadataURI`, and its `PRIVATE_HOSTNAME_RE` did not cover the link-local range the metadata endpoint lives in.

## Change

- Validate `metadataURI` before fetching: reject a private/internal host (reusing `isPrivateHostname`) and reject non-`http(s)` schemes.
- Add the link-local range `169.254.0.0/16` (which contains `169.254.169.254`) to `PRIVATE_HOSTNAME_RE`, so the endpoint probe flags it too.

## Tests

Adds a regression test that a link-local `metadataURI` is never fetched. Against the current code it fails (the address is fetched):

```
AssertionError: expected "spy" to not be called at all, but actually been called 1 times
```

With the fix it passes and the full suite stays green:

```
Test Files  39 passed (39)
      Tests  633 passed (633)
```
