### PR TITLE
fix(probe-endpoint): resolve hostname and check for private addresses

### DIFF
--- a/src/__tests__/probe-endpoint.test.ts
+++ b/src/__tests__/probe-endpoint.test.ts
@@ -1,8 +1,30 @@
-import { afterEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import {
   isPrivateHostname,
+  isPrivateResolvedAddress,
   probeEndpoint,
 } from "../cli/commands/probe-endpoint.js"
+
+vi.mock("node:dns/promises", async importOriginal => {
+  const actual = await importOriginal<typeof import("node:dns/promises")>()
+  return { ...actual, lookup: vi.fn() }
+})
+
+async function mockResolves(addresses: string[]) {
+  const dns = await import("node:dns/promises")
+  ;(dns.lookup as ReturnType<typeof vi.fn>).mockResolvedValue(
+    addresses.map(address => ({
+      address,
+      family: address.includes(":") ? 6 : 4,
+    })),
+  )
+}
+
+beforeEach(async () => {
+  // Default: hostnames resolve to a public address so existing behavior-only
+  // tests don't need to know about DNS resolution at all.
+  await mockResolves(["93.184.216.34"])
+})
 
 afterEach(() => {
   vi.unstubAllGlobals()
@@ -217,6 +239,65 @@ describe("probeEndpoint", () => {
     expect(result.level).toBe("warn")
     expect(result.message).toContain("private/internal")
     expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it("warns without fetching when a public-looking hostname resolves to a private address (DNS rebinding / misconfiguration)", async () => {
+    await mockResolves(["127.0.0.1"])
+    const fetchSpy = vi.fn()
+    vi.stubGlobal("fetch", fetchSpy)
+
+    const result = await probeEndpoint(
+      "https://attacker-controlled.example/api",
+    )
+    expect(result.level).toBe("warn")
+    expect(result.message).toContain("resolves to a private/internal address")
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it("warns when a hostname resolves to a cloud-metadata address among multiple A/AAAA records", async () => {
+    await mockResolves(["93.184.216.34", "169.254.169.254"])
+    const fetchSpy = vi.fn()
+    vi.stubGlobal("fetch", fetchSpy)
+
+    const result = await probeEndpoint("https://multi-homed.example/api")
+    expect(result.level).toBe("warn")
+    expect(result.message).toContain("resolves to a private/internal address")
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it("proceeds to fetch when DNS resolution fails (lets fetch surface the real network error)", async () => {
+    const dns = await import("node:dns/promises")
+    ;(dns.lookup as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("ENOTFOUND"),
+    )
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 401 })),
+    )
+
+    const result = await probeEndpoint("https://nonexistent.example/api")
+    expect(result.level).toBe("pass")
+    expect(result.status).toBe(401)
+  })
+})
+
+describe("isPrivateResolvedAddress", () => {
+  it("returns false when all resolved addresses are public", async () => {
+    await mockResolves(["93.184.216.34"])
+    expect(await isPrivateResolvedAddress("example.com")).toBe(false)
+  })
+
+  it("returns true when any resolved address is private", async () => {
+    await mockResolves(["93.184.216.34", "10.0.0.5"])
+    expect(await isPrivateResolvedAddress("example.com")).toBe(true)
+  })
+
+  it("returns false when DNS resolution fails", async () => {
+    const dns = await import("node:dns/promises")
+    ;(dns.lookup as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("ENOTFOUND"),
+    )
+    expect(await isPrivateResolvedAddress("nonexistent.example")).toBe(false)
   })
 })
 

--- a/src/cli/commands/probe-endpoint.ts
+++ b/src/cli/commands/probe-endpoint.ts
@@ -1,3 +1,4 @@
+import { lookup } from "node:dns/promises"
 import pc from "picocolors"
 
 export interface ProbeResult {
@@ -11,9 +12,13 @@ export interface ProbeResult {
 // hex `0x7f.0.0.1`, partial dotted forms like `127.1`, and IPv4-mapped IPv6
 // like `::ffff:169.254.169.254` / `::ffff:a9fe:a9a9`) are numerically
 // range-checked; other names fall back to a literal-name regex. This guard
-// does not resolve DNS, so names that resolve to private IPs (and DNS
-// rebinding) require a resolve-and-check / pinned connection and are tracked
-// as follow-up hardening.
+// alone does not resolve DNS, so a hostname that itself looks public but
+// resolves to a private/internal address (or is rebound to one) would slip
+// past it — see `isPrivateResolvedAddress` below, which is applied in
+// addition to this check before the endpoint is ever fetched. A fully
+// connect-time-pinned request (resolve once, dial the validated IP
+// directly) would close the remaining DNS-rebinding TOCTOU window and is
+// tracked as further hardening.
 //
 // Rejected ranges:
 //   - 0.0.0.0/8               unspecified / "this network"
@@ -145,6 +150,26 @@ export function isPrivateHostname(hostname: string): boolean {
   return PRIVATE_HOSTNAME_RE.test(hostname)
 }
 
+// Resolves `hostname` and reports whether any returned address is
+// private/internal. This closes the gap left by `isPrivateHostname` alone:
+// a public-looking DNS name can still resolve inward (misconfiguration or
+// deliberate DNS rebinding), and the actual fetch connects to whatever the
+// resolver returns, not to the string that was checked. Resolution failures
+// are not treated as private here — the subsequent `fetch` call will
+// surface the real network error with better context.
+export async function isPrivateResolvedAddress(
+  hostname: string,
+): Promise<boolean> {
+  let addresses: string[]
+  try {
+    const results = await lookup(hostname, { all: true, verbatim: true })
+    addresses = results.map(r => r.address)
+  } catch {
+    return false
+  }
+  return addresses.some(address => isPrivateHostname(address))
+}
+
 export async function probeEndpoint(endpoint: string): Promise<ProbeResult> {
   const hostname = new URL(endpoint).hostname
   if (isPrivateHostname(hostname)) {
@@ -152,6 +177,14 @@ export async function probeEndpoint(endpoint: string): Promise<ProbeResult> {
       status: 0,
       level: "warn",
       message: `Endpoint hostname "${hostname}" appears to be a private/internal address`,
+    }
+  }
+
+  if (await isPrivateResolvedAddress(hostname)) {
+    return {
+      status: 0,
+      level: "warn",
+      message: `Endpoint hostname "${hostname}" resolves to a private/internal address`,
     }
   }
 


### PR DESCRIPTION
Fixes #13.

## Root cause
`isPrivateHostname()` is a lexical guard: it only inspects the hostname string as written in the URL. A hostname that looks public but resolves to a private/internal address (misconfiguration, or an attacker pointing a DNS record inward, e.g. at `169.254.169.254`) passes the check, and `probeEndpoint()` then `fetch()`es whatever the resolver actually returns.

## Fix
Adds `isPrivateResolvedAddress()`, which resolves the hostname via `node:dns/promises` (`lookup(..., { all: true })`) and checks every returned A/AAAA record against the same private-range logic already used for IP literals. `probeEndpoint()` now applies both the lexical guard and the resolve-and-check before ever issuing a request. DNS resolution failures are not treated as private — they fall through so `fetch()` surfaces the real network error.

## Known residual
A narrow TOCTOU window remains between this check and the actual `fetch()` connect, since `fetch` re-resolves independently (classic DNS rebinding). Fully closing it needs a connect-time-pinned request (resolve once, dial the validated IP directly) — left as further hardening, consistent with the comment already in this file before this change.

## Testing
6 new regression tests: single/multi-address private resolution, a cloud-metadata address mixed in with a public one, resolution-failure fallthrough, and direct `isPrivateResolvedAddress()` coverage. `probe-endpoint.test.ts` + `verify-probe.test.ts`: 50/50 passing.

Note: this local environment runs Node 18.20.8, under which several unrelated test files (`x402-scheme.test.ts`, `eip3009-auth.test.ts`, etc.) fail with `crypto is not defined` — global WebCrypto isn't exposed until Node 20+. Confirmed this is pre-existing and unrelated to this change (same failures occur on a clean checkout of `main` without these commits, in files this PR does not touch).